### PR TITLE
convert key to string by default

### DIFF
--- a/msal_streamlit_authentication/__init__.py
+++ b/msal_streamlit_authentication/__init__.py
@@ -35,6 +35,6 @@ def msal_authentication(
         class_name=class_name,
         html_id=html_id,
         default=None,
-        key=key
+        key=str(key)
     )
     return authenticated_user_profile


### PR DESCRIPTION
Fixes #45 where example code uses a int for key, but Streamlit 1.41+ wants string for key.  This will now accept either int or string and keep examples working without having to change them everywhere.